### PR TITLE
Fix warnings and `API update required` window in Unity 2020.2

### DIFF
--- a/Editor/Scripts/MarkdownHandleImages.cs
+++ b/Editor/Scripts/MarkdownHandleImages.cs
@@ -156,12 +156,20 @@ namespace MG.MDV
                 return false;
             }
 
+#if UNITY_2020_2_OR_NEWER
+            if( req.Request.result == UnityWebRequest.Result.ProtocolError )
+#else
             if( req.Request.isHttpError )
+#endif
             {
                 Debug.LogError( string.Format( "HTTP Error: {0} - {1} {2}", req.URL, req.Request.responseCode, req.Request.error ) );
                 mTextureCache[ req.URL ] = null;
             }
+#if UNITY_2020_2_OR_NEWER
+            else if( req.Request.result == UnityWebRequest.Result.ConnectionError )
+#else
             else if( req.Request.isNetworkError )
+#endif
             {
                 Debug.LogError( string.Format( "Network Error: {0} - {1}", req.URL, req.Request.error ) );
                 mTextureCache[ req.URL ] = null;

--- a/Editor/Scripts/MarkdownImporter.cs
+++ b/Editor/Scripts/MarkdownImporter.cs
@@ -1,7 +1,11 @@
 ﻿#if UNITY_2018_1_OR_NEWER
 
 using UnityEngine;
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+#else
 using UnityEditor.Experimental.AssetImporters;
+#endif
 using System.IO;
 
 namespace MG.MDV


### PR DESCRIPTION
1. Fixes #9 
2. Prevents unity from running the automatic updater
	![APIUpdaterWarningDialog](https://docs.unity3d.com/uploads/Main/APIUpdaterWarningDialog.png)

Full backwards compatible for unity 2020.1 and below

Thank you for this project, it was really needed in unity. Keep up the good job =)