### PR TITLE
fix: handler images for packages imported from disk

### DIFF
--- a/Editor/Scripts/MarkdownHandleImages.cs
+++ b/Editor/Scripts/MarkdownHandleImages.cs
@@ -116,8 +116,8 @@ namespace MG.MDV
                 return string.Format( "file:///{0}{1}", projectDir, url );
             }
 
-            var assetDir = Path.GetDirectoryName( CurrentPath );
-            return "file:///" + Utils.PathNormalise( string.Format( "{0}/{1}/{2}", projectDir, assetDir, url ) );
+            var assetDir = Path.GetDirectoryName(Path.GetFullPath( CurrentPath ));
+            return "file:///" + Utils.PathNormalise( string.Format( "{0}/{1}", assetDir, url ) );
         }
 
         //------------------------------------------------------------------------------


### PR DESCRIPTION
Hi,
I really like the package! I find it very useful. 
I think that I found a small bug. I've opened the PR with my proposal solution. More details below. 

## Summary

Markdown files may be located outside the project directory, e.g. in a case when one imports packages from the disk.
As the result, when opening the markdown file with an image with a relative path to the file, an exception is thrown in the console with "HTTP 404 ERROR".
This commit resolves the issue.

## Bug reproduction

1. Create a package with the markdown file with an image with a relative path to the file outside the project directory.
2. Create a Unity project and import the package (from disk).
3. Open the markdown file in the inspector. An exception should be thrown.

