### PR TITLE
fix: Change mouse cursor to link cursor when hovering links

### DIFF
--- a/Editor/Scripts/Layout/Content.cs
+++ b/Editor/Scripts/Layout/Content.cs
@@ -31,8 +31,14 @@ namespace MG.MDV
             if( string.IsNullOrEmpty( Link ) )
             {
                 GUI.Label( Location, Payload, context.Apply( Style ) );
+                return;
             }
-            else if( GUI.Button( Location, Payload, context.Apply( Style ) ) )
+
+#if UNITY_EDITOR
+            UnityEditor.EditorGUIUtility.AddCursorRect( Location, UnityEditor.MouseCursor.Link );
+#endif
+
+            if( GUI.Button( Location, Payload, context.Apply( Style ) ) )
             {
                 if( Regex.IsMatch( Link, @"^\w+:", RegexOptions.Singleline ) )
                 {


### PR DESCRIPTION
This change fixes the fact that there is no visual feedback when hovering links.

`UnityEditor.EditorGUIUtility.AddCursorRect` is supported by the minimum Unity Version supported (2018.4).

Fully qualified reference wrapped in `UNITY_EDITOR` because adding a `UnityEditor` dependency here feels wrong as someone may want to use/try to use this package in a build?
