### PR TITLE
feat(MarkdownViewer): Allow external control of view-width when rendering via delegate

### DIFF
--- a/Editor/Scripts/MarkdownViewer.cs
+++ b/Editor/Scripts/MarkdownViewer.cs
@@ -1,4 +1,5 @@
-﻿using Markdig;
+﻿using System;
+using Markdig;
 using UnityEditor;
 using UnityEngine;
 using Markdig.Extensions.JiraLinks;
@@ -15,6 +16,8 @@ namespace MG.MDV
         private string          mCurrentPath     = string.Empty;
         private HandlerImages   mHandlerImages   = new HandlerImages();
         private HandlerNavigate mHandlerNavigate = new HandlerNavigate();
+
+        private Func<float> mViewWidthProvider = () => EditorGUIUtility.currentViewWidth; 
 
         private Layout          mLayout          = null;
         private bool            mRaw             = false;
@@ -36,6 +39,16 @@ namespace MG.MDV
             mHandlerNavigate.History     = mHistory;
             mHandlerNavigate.FindBlock   = ( id ) => mLayout.Find( id );
             mHandlerNavigate.ScrollTo    = ( pos ) => {}; // TODO: mScrollPos.y = pos;
+        }
+
+        public MarkdownViewer( GUISkin skin, string path, string content, Func<float> viewWidthProvider ) : this( skin, path, content )
+        {
+            if (viewWidthProvider == null)
+            {
+                throw new ArgumentNullException(nameof(viewWidthProvider));
+            }
+            
+            mViewWidthProvider = viewWidthProvider;
         }
 
 
@@ -102,7 +115,7 @@ namespace MG.MDV
 
             // useable width of inspector windows
 
-            var contentWidth = EditorGUIUtility.currentViewWidth - mSkin.verticalScrollbar.fixedWidth - 2.0f * Margin.x;
+            var contentWidth = mViewWidthProvider() - mSkin.verticalScrollbar.fixedWidth - 2.0f * Margin.x;
 
 
             // draw content


### PR DESCRIPTION
Allow consumers to override the default width-provider for the `MarkdownViewer` class via a constructor overload.

This is useful for cases when `EditorGUIUtility.currentViewWidth` returns an "incorrect" value such as when `MarkdownViewer.Draw()` is called in a `IMGUIContainer`'s `onGUIHandler` delegate.

The two example screenshots below show the _UnityPackageMangerWindow_ with a simple extension added via _UnityPackageManagerExtension_ that uses `MarkdownViewer` inside of a _IMGUIContainer_ element to show a packages' `Readme.md` and `Changelog.md` directly in the package manager window.

`MarkdownViewer` used `EditorGUIUtility.currentViewWidth` internally to control the width of the rendered markdown however in this case the `currentViewWidth` property returns the width of the window-panel instead of the width of the `IMGUIContainer`  notice how the white "view-markdown-source" button is not visible.

Before:
![image](https://user-images.githubusercontent.com/1384288/218778848-91cafb2a-874d-416b-88a1-b15c7bbdd4b4.png)

Fixed by using the newly added constructor overload and injecting a `Func<float>` delegate that returns the width of the `IMGUIContainer`s `resolvedStyle` property, e.g:
```csharp
_markdownViewer = new MarkdownViewer(_guiSkin, assetPath, content, () => resolvedStyle.width);
```

After:
![image](https://user-images.githubusercontent.com/1384288/218779078-a2893921-2c36-4fdb-be79-902721522e95.png)

