### PR TITLE
fix(Images): Don't use mipmaps for images

### DIFF
--- a/Editor/Scripts/MarkdownHandleImages.cs
+++ b/Editor/Scripts/MarkdownHandleImages.cs
@@ -71,7 +71,7 @@ namespace MG.MDV
                 else
                 {
                     IsGif   = false;
-                    Request = UnityWebRequestTexture.GetTexture( url );
+                    Request = new UnityWebRequest(url, "GET", new DownloadHandlerBuffer(), null);
                 }
 
                 Request.SendWebRequest();
@@ -93,9 +93,14 @@ namespace MG.MDV
             }
 
             public Texture GetTexture()
-            {
-                var handler = Request.downloadHandler as DownloadHandlerTexture;
-                return handler != null ? handler.texture : null;
+            {                
+                var downloadHandler = Request.downloadHandler as DownloadHandlerBuffer;
+                
+                if (downloadHandler == null) return null;
+
+                var texture = new Texture2D( 2, 2, TextureFormat.RGBA32, false);
+                texture.LoadImage(downloadHandler.data, true);
+                return texture;
             }
         }
 


### PR DESCRIPTION
In newer versions of Unity texture mip-levels can be clamped to a non-zero value due to `QualitySettings.masterTextureLimit` / `QualitySettings.globalTextureMipmapLimit` causing images in the markdown-renderer to look pixelated, they should always be rendered at 1 to 1 pixel resolution.

Example: In a project with Texture Quality setting at 'Quarter Res' the readme image looks like this:

![image](https://github.com/gwaredd/UnityMarkdownViewer/assets/1384288/2912d537-b8bc-4205-9395-be34b98879bc)

