### PR TITLE
Specifying the markdiag.dll assembly to use to prevent conflicts when using other pakcages with the same assembly

### DIFF
--- a/Editor/Mischief.MDV.Editor.asmdef
+++ b/Editor/Mischief.MDV.Editor.asmdef
@@ -1,14 +1,18 @@
 {
     "name": "Mischief.MDV.Editor",
+    "rootNamespace": "MG.MDV",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Markdig.dll"
+    ],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mischief.markdownviewer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "displayName": "Unity Markdown Viewer",
   "description": "Editor inspector for markdown files",
   "unity": "2018.4",


### PR DESCRIPTION
The asmdef does not defines used assemblies which can lead to conflict when another package is using the same assembly (even with a different name).
By default unity will link all assemblies.

The issue was found when using com.unity.ai.assistant 1.0.0-pre12 on a project the includes markdig.dll too