### PR TITLE
feat: add dedicated Markdown Viewer Editor Window

### DIFF
--- a/Editor/Scripts/MarkdownMenus.cs
+++ b/Editor/Scripts/MarkdownMenus.cs
@@ -8,6 +8,15 @@ namespace MG.MDV
 {
     public class Menus
     {
+
+        static bool IsMarkdownSelected()
+        {
+            var path = AssetDatabase.GetAssetPath( Selection.activeObject );
+            if( string.IsNullOrEmpty( path ) ) return false;
+            var ext = Path.GetExtension( path ).ToLower();
+            return ext == ".md" || ext == ".markdown";
+        }
+
         static string GetFilePath( string filename )
         {
             var path = AssetDatabase.GetAssetPath( Selection.activeObject );
@@ -23,6 +32,9 @@ namespace MG.MDV
 
             return AssetDatabase.GenerateUniqueAssetPath( path + "/" + filename );
         }
+
+
+        // create
 
         [MenuItem( "Assets/Create/Markdown" )]
         static void CreateMarkdown()
@@ -47,5 +59,44 @@ namespace MG.MDV
 
             Selection.activeObject = AssetDatabase.LoadAssetAtPath<TextAsset>( filepath );
         }
+
+        // create sub-menu
+
+        [MenuItem( "Assets/Markdown/Create" )]
+        static void CreateMarkdownSubmenu()
+        {
+            CreateMarkdown();
+        }
+
+        // open
+
+        [MenuItem( "Assets/Markdown/Open", false, 1000 )]
+        static void OpenMarkdown()
+        {
+            var asset = Selection.activeObject as TextAsset;
+            if( asset == null ) return;
+            var window = EditorWindow.GetWindow<MarkdownWindow>( "Markdown Viewer" );
+            window.LoadMarkdownFile( asset );
+            window.Show();
+        }
+
+        [MenuItem( "Assets/Markdown/Open", true )]
+        static bool OpenMarkdownValidate() => IsMarkdownSelected();
+
+
+        // edit
+
+        [MenuItem( "Assets/Markdown/Edit", false, 1001 )]
+        static void EditMarkdown()
+        {
+            var path = AssetDatabase.GetAssetPath( Selection.activeObject );
+            if( !string.IsNullOrEmpty( path ) )
+            {
+                EditorUtility.OpenWithDefaultApp( path );
+            }
+        }
+
+        [MenuItem( "Assets/Markdown/Edit", true )]
+        static bool EditMarkdownValidate() => IsMarkdownSelected();
     }
 }

--- a/Editor/Scripts/MarkdownPreferences.cs
+++ b/Editor/Scripts/MarkdownPreferences.cs
@@ -8,23 +8,26 @@ namespace MG.MDV
 {
     public static class Preferences
     {
-        private static readonly string KeyJIRA     = "MG/MDV/JIRA";
-        private static readonly string KeyPipedTables     = "MG/MDV/PIPED";
-        private static readonly string KeyPipedTablesRequireHeaderSeparator     = "MG/MDV/PIPED/USEHSEP";
-        private static readonly string KeyHTML     = "MG/MDV/HTML";
-        private static readonly string KeyDarkSkin = "MG/MDV/DarkSkin";
+        private static readonly string KeyJIRA                              = "MG/MDV/JIRA";
+        private static readonly string KeyPipedTables                       = "MG/MDV/PIPED";
+        private static readonly string KeyPipedTablesRequireHeaderSeparator = "MG/MDV/PIPED/USEHSEP";
+        private static readonly string KeyHTML                              = "MG/MDV/HTML";
+        private static readonly string KeyDarkSkin                          = "MG/MDV/DarkSkin";
+        private static readonly string KeyOpenInViewer                      = "MG/MDV/OpenInViewer";
 
-        private static string mJIRA        = string.Empty;
-        private static bool   mPipedTables   = true;
-        private static bool   mPipedTablesRequireHeaderSeparator   = true;
-        private static bool   mStripHTML   = true;
-        private static bool   mPrefsLoaded = false;
-        private static bool   mDarkSkin    = EditorGUIUtility.isProSkin ;
+        private static string mJIRA                              = string.Empty;
+        private static bool   mPipedTables                       = true;
+        private static bool   mPipedTablesRequireHeaderSeparator = true;
+        private static bool   mStripHTML                         = true;
+        private static bool   mPrefsLoaded                       = false;
+        private static bool   mDarkSkin                          = EditorGUIUtility.isProSkin;
+        private static bool   mOpenInViewer                      = false;
 
         public static string JIRA         { get { LoadPrefs(); return mJIRA; } }
         public static bool   StripHTML    { get { LoadPrefs(); return mStripHTML; } }
         public static bool   DarkSkin     { get { LoadPrefs(); return mDarkSkin; } }
-        
+        public static bool   OpenInViewer { get { LoadPrefs(); return mOpenInViewer; } }
+
         public static bool   PipedTables  { get { LoadPrefs(); return mPipedTables; } }
         public static bool   PipedTablesRequireRequireHeaderSeparator  { get { LoadPrefs(); return mPipedTablesRequireHeaderSeparator; } }
 
@@ -32,12 +35,13 @@ namespace MG.MDV
         {
             if( !mPrefsLoaded )
             {
-                mJIRA        = EditorPrefs.GetString( KeyJIRA, "" );
-                mStripHTML   = EditorPrefs.GetBool( KeyHTML, true );
-                mPipedTables   = EditorPrefs.GetBool( KeyPipedTables, true );
-                mPipedTablesRequireHeaderSeparator   = EditorPrefs.GetBool( KeyPipedTablesRequireHeaderSeparator, true );
-                mDarkSkin    = EditorPrefs.GetBool( KeyDarkSkin, EditorGUIUtility.isProSkin );
-                mPrefsLoaded = true;
+                mJIRA                              = EditorPrefs.GetString( KeyJIRA, "" );
+                mStripHTML                         = EditorPrefs.GetBool( KeyHTML, true );
+                mPipedTables                       = EditorPrefs.GetBool( KeyPipedTables, true );
+                mPipedTablesRequireHeaderSeparator = EditorPrefs.GetBool( KeyPipedTablesRequireHeaderSeparator, true );
+                mDarkSkin                          = EditorPrefs.GetBool( KeyDarkSkin, EditorGUIUtility.isProSkin );
+                mOpenInViewer                      = EditorPrefs.GetBool( KeyOpenInViewer, true );
+                mPrefsLoaded                       = true;
             }
         }
 
@@ -70,9 +74,10 @@ namespace MG.MDV
 
             EditorGUI.BeginChangeCheck();
 
-            mJIRA      = EditorGUILayout.TextField( "JIRA URL", mJIRA );
-            mStripHTML = EditorGUILayout.Toggle( "Strip HTML", mStripHTML );
-            mDarkSkin  = EditorGUILayout.Toggle( "Dark Skin", mDarkSkin );
+            mJIRA         = EditorGUILayout.TextField( "JIRA URL", mJIRA );
+            mStripHTML    = EditorGUILayout.Toggle( "Strip HTML", mStripHTML );
+            mDarkSkin     = EditorGUILayout.Toggle( "Dark Skin", mDarkSkin );
+            mOpenInViewer = EditorGUILayout.Toggle( "Open files in editor", mOpenInViewer );
 
             EditorGUI.EndChangeCheck();
 
@@ -80,6 +85,7 @@ namespace MG.MDV
             {
                 EditorPrefs.SetString( KeyJIRA, mJIRA );
                 EditorPrefs.SetBool( KeyHTML, mStripHTML );
+                EditorPrefs.SetBool( KeyOpenInViewer, mOpenInViewer );
             }
         }
     }

--- a/Editor/Scripts/MarkdownWindow.cs
+++ b/Editor/Scripts/MarkdownWindow.cs
@@ -27,9 +27,14 @@ namespace MG.MDV
             window.Show();
         }
 
-        [OnOpenAsset(1)]
+        [OnOpenAsset]
         public static bool OnOpenAsset(EntityId instanceID, int line)
         {
+            if (!Preferences.OpenInViewer)
+            {
+                return false;
+            }
+
             var obj = EditorUtility.EntityIdToObject(instanceID);
 
             if (obj is TextAsset textAsset)

--- a/Editor/Scripts/MarkdownWindow.cs
+++ b/Editor/Scripts/MarkdownWindow.cs
@@ -24,9 +24,10 @@ namespace MG.MDV
         }
 
         [OnOpenAsset(1)]
-        public static bool OnOpenAsset(int instanceID, int line)
+        public static bool OnOpenAsset(EntityId instanceID, int line)
         {
-            var obj = EditorUtility.InstanceIDToObject(instanceID);
+            var obj = EditorUtility.EntityIdToObject(instanceID);
+
             if (obj is TextAsset textAsset)
             {
                 var path = AssetDatabase.GetAssetPath(textAsset);

--- a/Editor/Scripts/MarkdownWindow.cs
+++ b/Editor/Scripts/MarkdownWindow.cs
@@ -1,0 +1,260 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.Callbacks;
+
+namespace MG.MDV
+{
+    public class MarkdownWindow : EditorWindow
+    {
+        private TextAsset mMarkdownFile;
+        private string mLoadedContent;
+        private MarkdownViewer mViewer;
+        private Vector2 mScrollPosition;
+        private bool mSyncSelection = true;
+
+        private GUISkin mSkinLight;
+        private GUISkin mSkinDark;
+
+        [MenuItem("Window/Markdown Viewer Window")]
+        public static void ShowWindow()
+        {
+            var window = GetWindow<MarkdownWindow>("Markdown Viewer");
+            window.Show();
+        }
+
+        [OnOpenAsset(1)]
+        public static bool OnOpenAsset(int instanceID, int line)
+        {
+            var obj = EditorUtility.InstanceIDToObject(instanceID);
+            if (obj is TextAsset textAsset)
+            {
+                var path = AssetDatabase.GetAssetPath(textAsset);
+                var ext = Path.GetExtension(path).ToLower();
+                if (ext == ".md" || ext == ".markdown")
+                {
+                    var window = GetWindow<MarkdownWindow>("Markdown Viewer");
+                    window.LoadMarkdownFile(textAsset);
+                    window.Show();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void OnEnable()
+        {
+            LoadSkins();
+            EditorApplication.update += UpdateRequests;
+            
+            if (mMarkdownFile != null)
+            {
+                ReloadCurrentFile();
+            }
+            else if (Selection.activeObject is TextAsset textAsset)
+            {
+                var path = AssetDatabase.GetAssetPath(textAsset);
+                var ext = Path.GetExtension(path).ToLower();
+                if (ext == ".md" || ext == ".markdown")
+                {
+                    LoadMarkdownFile(textAsset);
+                }
+            }
+        }
+
+        private void OnDisable()
+        {
+            EditorApplication.update -= UpdateRequests;
+            mViewer = null;
+        }
+
+        private void UpdateRequests()
+        {
+            if (mViewer != null && mViewer.Update())
+            {
+                Repaint();
+            }
+
+            // Auto-reload if file contents changed on disk
+            if (mMarkdownFile != null && mMarkdownFile.text != mLoadedContent)
+            {
+                ReloadCurrentFile();
+            }
+        }
+
+        private void OnSelectionChange()
+        {
+            if (mSyncSelection)
+            {
+                if (Selection.activeObject is TextAsset textAsset)
+                {
+                    var path = AssetDatabase.GetAssetPath(textAsset);
+                    var ext = Path.GetExtension(path).ToLower();
+                    if (ext == ".md" || ext == ".markdown")
+                    {
+                        LoadMarkdownFile(textAsset);
+                        Repaint();
+                    }
+                }
+            }
+        }
+
+        public void LoadMarkdownFile(TextAsset file)
+        {
+            if (mMarkdownFile == file && mViewer != null)
+            {
+                return;
+            }
+
+            mMarkdownFile = file;
+            ReloadCurrentFile();
+        }
+
+        private void ReloadCurrentFile()
+        {
+            LoadSkins();
+
+            if (mMarkdownFile != null)
+            {
+                var path = AssetDatabase.GetAssetPath(mMarkdownFile);
+                mLoadedContent = mMarkdownFile.text;
+                var skin = Preferences.DarkSkin ? mSkinDark : mSkinLight;
+                mViewer = new MarkdownViewer(skin, path, mLoadedContent, () => position.width);
+            }
+            else
+            {
+                mViewer = null;
+                mLoadedContent = null;
+            }
+        }
+
+        private void LoadSkins()
+        {
+            if (mSkinLight == null)
+            {
+                var path = AssetDatabase.GUIDToAssetPath("81f272e4a921a5448a30c0e40b4ea003");
+                if (!string.IsNullOrEmpty(path))
+                {
+                    mSkinLight = AssetDatabase.LoadAssetAtPath<GUISkin>(path);
+                }
+            }
+            if (mSkinDark == null)
+            {
+                var path = AssetDatabase.GUIDToAssetPath("8611e9e5923b6084997203d4997b4976");
+                if (!string.IsNullOrEmpty(path))
+                {
+                    mSkinDark = AssetDatabase.LoadAssetAtPath<GUISkin>(path);
+                }
+            }
+        }
+
+        private void OnGUI()
+        {
+            DrawToolbar();
+
+            if (mMarkdownFile == null)
+            {
+                DrawDragAndDropZone();
+                return;
+            }
+
+            if (mViewer == null)
+            {
+                ReloadCurrentFile();
+            }
+
+            if (mViewer == null)
+            {
+                EditorGUILayout.HelpBox("Failed to initialize Markdown Viewer.", MessageType.Error);
+                return;
+            }
+
+            mScrollPosition = EditorGUILayout.BeginScrollView(mScrollPosition);
+            mViewer.Draw();
+            EditorGUILayout.EndScrollView();
+        }
+
+        private void DrawToolbar()
+        {
+            using (new EditorGUILayout.HorizontalScope(EditorStyles.toolbar))
+            {
+                var newFile = (TextAsset)EditorGUILayout.ObjectField(mMarkdownFile, typeof(TextAsset), false, GUILayout.Width(250));
+                if (newFile != mMarkdownFile)
+                {
+                    if (newFile == null)
+                    {
+                        LoadMarkdownFile(null);
+                    }
+                    else
+                    {
+                        var path = AssetDatabase.GetAssetPath(newFile);
+                        var ext = Path.GetExtension(path).ToLower();
+                        if (ext == ".md" || ext == ".markdown")
+                        {
+                            LoadMarkdownFile(newFile);
+                        }
+                    }
+                }
+
+                GUILayout.Space(5);
+
+                mSyncSelection = GUILayout.Toggle(mSyncSelection, "Sync Selection", EditorStyles.toolbarButton);
+
+                GUILayout.FlexibleSpace();
+
+                if (GUILayout.Button("Reload", EditorStyles.toolbarButton))
+                {
+                    ReloadCurrentFile();
+                }
+
+                if (GUILayout.Button("Clear", EditorStyles.toolbarButton))
+                {
+                    LoadMarkdownFile(null);
+                }
+            }
+        }
+
+        private void DrawDragAndDropZone()
+        {
+            var rect = GUILayoutUtility.GetRect(0, 0, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+            GUI.Box(rect, "Drag and drop a Markdown (.md) file here", new GUIStyle(GUI.skin.box)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 14,
+                normal = { textColor = Color.gray }
+            });
+
+            var evt = Event.current;
+            switch (evt.type)
+            {
+                case EventType.DragUpdated:
+                case EventType.DragPerform:
+                    if (!rect.Contains(evt.mousePosition))
+                        break;
+
+                    DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+
+                    if (evt.type == EventType.DragPerform)
+                    {
+                        DragAndDrop.AcceptDrag();
+                        foreach (var draggedObject in DragAndDrop.objectReferences)
+                        {
+                            if (draggedObject is TextAsset textAsset)
+                            {
+                                var path = AssetDatabase.GetAssetPath(textAsset);
+                                var ext = Path.GetExtension(path).ToLower();
+                                if (ext == ".md" || ext == ".markdown")
+                                {
+                                    LoadMarkdownFile(textAsset);
+                                    Repaint();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    evt.Use();
+                    break;
+            }
+        }
+    }
+}

--- a/Editor/Scripts/MarkdownWindow.cs
+++ b/Editor/Scripts/MarkdownWindow.cs
@@ -7,11 +7,15 @@ namespace MG.MDV
 {
     public class MarkdownWindow : EditorWindow
     {
-        private TextAsset mMarkdownFile;
+        [SerializeField] private TextAsset mMarkdownFile;
+        [SerializeField] private Vector2 mScrollPosition;
+        [SerializeField] private bool mSyncSelection = true;
+
         private string mLoadedContent;
         private MarkdownViewer mViewer;
-        private Vector2 mScrollPosition;
-        private bool mSyncSelection = true;
+
+        private Hash128 mLoadedDependencyHash;
+        private double mNextAutoReloadCheckTime;
 
         private GUISkin mSkinLight;
         private GUISkin mSkinDark;
@@ -75,10 +79,17 @@ namespace MG.MDV
                 Repaint();
             }
 
-            // Auto-reload if file contents changed on disk
-            if (mMarkdownFile != null && mMarkdownFile.text != mLoadedContent)
+            // Auto-reload if file contents changed (poll dependency hash at a modest interval)
+            if (mMarkdownFile != null && EditorApplication.timeSinceStartup >= mNextAutoReloadCheckTime)
             {
-                ReloadCurrentFile();
+                mNextAutoReloadCheckTime = EditorApplication.timeSinceStartup + 0.5d;
+
+                var path = AssetDatabase.GetAssetPath(mMarkdownFile);
+                var currentHash = AssetDatabase.GetAssetDependencyHash(path);
+                if (currentHash != mLoadedDependencyHash)
+                {
+                    ReloadCurrentFile();
+                }
             }
         }
 
@@ -118,6 +129,9 @@ namespace MG.MDV
             {
                 var path = AssetDatabase.GetAssetPath(mMarkdownFile);
                 mLoadedContent = mMarkdownFile.text;
+                mLoadedDependencyHash = AssetDatabase.GetAssetDependencyHash(path);
+                mNextAutoReloadCheckTime = EditorApplication.timeSinceStartup + 0.5d;
+
                 var skin = Preferences.DarkSkin ? mSkinDark : mSkinLight;
                 mViewer = new MarkdownViewer(skin, path, mLoadedContent, () => position.width);
             }
@@ -125,6 +139,8 @@ namespace MG.MDV
             {
                 mViewer = null;
                 mLoadedContent = null;
+                mLoadedDependencyHash = default;
+                mNextAutoReloadCheckTime = 0d;
             }
         }
 
@@ -232,9 +248,24 @@ namespace MG.MDV
                     if (!rect.Contains(evt.mousePosition))
                         break;
 
-                    DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+                    var hasMarkdown = false;
+                    foreach (var draggedObject in DragAndDrop.objectReferences)
+                    {
+                        if (draggedObject is TextAsset textAsset)
+                        {
+                            var path = AssetDatabase.GetAssetPath(textAsset);
+                            var ext = Path.GetExtension(path).ToLower();
+                            if (ext == ".md" || ext == ".markdown")
+                            {
+                                hasMarkdown = true;
+                                break;
+                            }
+                        }
+                    }
 
-                    if (evt.type == EventType.DragPerform)
+                    DragAndDrop.visualMode = hasMarkdown ? DragAndDropVisualMode.Copy : DragAndDropVisualMode.Rejected;
+
+                    if (evt.type == EventType.DragPerform && hasMarkdown)
                     {
                         DragAndDrop.AcceptDrag();
                         foreach (var draggedObject in DragAndDrop.objectReferences)

--- a/Editor/Scripts/MarkdownWindow.cs.meta
+++ b/Editor/Scripts/MarkdownWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ecd1fe6ba17648143a9f5dc9db49ae2a

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unity Markdown Viewer (UMV)
-> A markdown viewer for unity
+> A markdown viewer for Unity
 
-UMV is a Unity editor extension for displaying markdown files in the inspector window.
+UMV is a Unity editor extension for displaying markdown files in the inspector window and a dedicated editor window.
 
 It should _just work_ without any setup or configuration.
 
@@ -14,16 +14,47 @@ cd Packages
 git clone https://github.com/gwaredd/UnityMarkdownViewer.git
 ```
 
-Alternatively import the `.unitypackage` file from the [releases page](https://github.com/gwaredd/UnityMarkdownViewer/releases).
-
-
-
-## Screenshots
-
-### Dark Skin
-
 ![Screenshot](https://raw.githubusercontent.com/gwaredd/UnityMarkdownViewer/main/Documentation/images/screenshot_dark.png)
 
-### Light Skin
+## Usage
 
-![Screenshot](https://raw.githubusercontent.com/gwaredd/UnityMarkdownViewer/main/Documentation/images/screenshot_light.png)
+### Inspector
+
+Selecting any `.md` or `.markdown` file in the Project window renders it in the Inspector automatically.
+
+### Markdown Viewer Window
+
+Open the dedicated viewer via **Window → Markdown Viewer Window**. The window:
+
+- Displays the currently selected markdown file.
+- Stays in sync with Project window selection when **Sync Selection** is enabled in the toolbar.
+- Auto-reloads when the file changes on disk.
+- Accepts drag and drop of markdown files when no file is loaded.
+- Can be pinned to any layout position like any other editor window.
+
+### Context Menu
+
+Right-clicking a `.md` or `.markdown` file in the Project window shows an **Assets → Markdown** submenu (greyed out for non-markdown files):
+
+| Item | Action |
+|------|--------|
+| **Markdown → Open** | Opens the file in the Markdown Viewer Window |
+| **Markdown → Edit** | Opens the file in the external editor registered with the OS for that file type |
+| **Markdown → Create** | Creates a new markdown file in the selected folder |
+
+A new markdown file can also be created via **Assets → Create → Markdown**.
+
+### Double-click Behaviour
+
+By default, double-clicking a markdown file opens it in the Markdown Viewer Window. This can be changed in preferences so that double-clicking falls through to the external editor instead (see [Preferences](#preferences) below).
+
+## Preferences
+
+Open **Edit → Preferences → Markdown** (or **Unity → Preferences → Markdown** on macOS) to configure:
+
+| Setting | Description |
+|---------|-------------|
+| **Open files in editor** | When enabled (default), double-clicking a `.md`/`.markdown` file opens the Markdown Viewer Window. Disable to use the external editor on double-click instead. |
+| **Dark Skin** | Toggle between light and dark rendering. Defaults to match the current Unity editor skin. |
+| **Strip HTML** | Strip raw HTML tags from rendered output. |
+| **JIRA URL** | Base URL for JIRA issue links (e.g. `https://yourproject.atlassian.net/browse/`). |


### PR DESCRIPTION
### Summary
This PR adds a dedicated `MarkdownWindow` (Editor Window) that allows developers to view and read markdown files independently of their Inspector selections.

### Why this is needed
Previously, markdown files could only be previewed directly inside the Inspector window. However, when developers are setting up scenes, editing components, or interacting with Hierarchy objects, the Inspector is overridden by the selected GameObjects, preventing them from reading markdown setup/guide files simultaneously.

### Key Features
1. **Access**: Added to the menu via `Window -> Markdown Viewer Window`.
2. **Double-Click Hook (`[OnOpenAsset]`)**: Double-clicking a `.md` or `.markdown` file in the Project window automatically opens it in this window instead of launching an external text editor.
3. **Sync Selection & Retention**:
   - Includes a **Sync Selection** toggle in the toolbar.
   - When checked: selecting a markdown asset in the project will automatically show it in the window. Selecting any non-markdown asset (e.g. GameObjects, Materials, folders) will keep the last viewed markdown file active.
   - When unchecked: locks the view onto the current markdown document.
4. **Drag & Drop support**: Shows a clean drag-and-drop zone box when no file is loaded, allowing files to be dragged directly into the window.
5. **Play Mode / Domain Reload Support**: Handles Unity assembly reloads gracefully. The viewer instance is safely restored when entering or exiting Play Mode.
6. **Auto-Reload**: Automatically detects updates or re-imports to the loaded file and repaints the layout.
<img width="1919" height="1079" alt="Screenshot 2026-06-22 173629" src="https://github.com/user-attachments/assets/4423ee2a-7c84-4644-b402-b9a3d44ef8e7" />
